### PR TITLE
An unsigned char fix and an errno change

### DIFF
--- a/source/directory.c
+++ b/source/directory.c
@@ -98,7 +98,8 @@ static int _FAT_directory_lfnLength (const char* name) {
 	}
 	// Make sure the name doesn't contain any control codes or codes not representable in UCS-2
 	for (i = 0; i < nameLength; i++) {
-		if (name[i] < 0x20 || name[i] >= ABOVE_UCS_RANGE) {
+		unsigned char ch = (unsigned char) name[i];
+		if (ch < 0x20 || ch >= ABOVE_UCS_RANGE) {
 			return -1;
 		}
 	}

--- a/source/fatdir.c
+++ b/source/fatdir.c
@@ -136,7 +136,7 @@ int _FAT_unlink_r (struct _reent *r, const char *path) {
 			if (!_FAT_directory_isDot (&dirContents)) {
 				// The directory had something in it that isn't a reference to itself or it's parent
 				_FAT_unlock(&partition->lock);
-				r->_errno = EPERM;
+				r->_errno = ENOTEMPTY;
 				return -1;
 			}
 			nextEntry = _FAT_directory_getNextEntry (partition, &dirContents);

--- a/source/fatdir.c
+++ b/source/fatdir.c
@@ -588,7 +588,6 @@ int _FAT_dirnext_r (struct _reent *r, DIR_ITER *dirState, char *filename, struct
 	// Make sure there is another file to report on
 	if (! state->validEntry) {
 		_FAT_unlock(&state->partition->lock);
-		r->_errno = ENOENT;
 		return -1;
 	}
 


### PR DESCRIPTION
Here are 3 commits that improve the standards compliance of libfat in some specific scenarios:
- compiling `_FAT_directory_lfnLength` with `char` equivalent to `signed char`;
- setting the correct value of `errno` when removing a non-empty directory;
- not setting `errno` at the end of a directory in `_FAT_dirnext` if no error occurred while reading.
