### PR TITLE
UStealth support for Wii U (Extrems)

### DIFF
--- a/source/partition.c
+++ b/source/partition.c
@@ -189,7 +189,7 @@ PARTITION* _FAT_partition_constructor_buf (const DISC_INTERFACE* disc, uint32_t 
 	}
 
 	// Make sure it is a valid MBR or boot sector
-	if ( (sectorBuffer[BPB_bootSig_55] != 0x55) || (sectorBuffer[BPB_bootSig_AA] != 0xAA)) {
+	if ((sectorBuffer[BPB_bootSig_55] != 0x55) || ((sectorBuffer[BPB_bootSig_AA] != 0xAA) && (sectorBuffer[BPB_bootSig_AA] != 0xAB))) {
 		return NULL;
 	}
 

--- a/source/partition.c
+++ b/source/partition.c
@@ -189,7 +189,7 @@ PARTITION* _FAT_partition_constructor_buf (const DISC_INTERFACE* disc, uint32_t 
 	}
 
 	// Make sure it is a valid MBR or boot sector
-	if ( (sectorBuffer[BPB_bootSig_55] != 0x55) || (sectorBuffer[BPB_bootSig_AA] != 0xAA && sectorBuffer[BPB_bootSig_AA] != 0xAB)) {
+	if ((sectorBuffer[BPB_bootSig_55] != 0x55) || ((sectorBuffer[BPB_bootSig_AA] != 0xAA) && (sectorBuffer[BPB_bootSig_AA] != 0xAB))) {
 		return NULL;
 	}
 

--- a/source/partition.c
+++ b/source/partition.c
@@ -189,7 +189,7 @@ PARTITION* _FAT_partition_constructor_buf (const DISC_INTERFACE* disc, uint32_t 
 	}
 
 	// Make sure it is a valid MBR or boot sector
-	if ((sectorBuffer[BPB_bootSig_55] != 0x55) || ((sectorBuffer[BPB_bootSig_AA] != 0xAA) && (sectorBuffer[BPB_bootSig_AA] != 0xAB))) {
+	if ( (sectorBuffer[BPB_bootSig_55] != 0x55) || (sectorBuffer[BPB_bootSig_AA] != 0xAA && sectorBuffer[BPB_bootSig_AA] != 0xAB)) {
 		return NULL;
 	}
 


### PR DESCRIPTION
This intends to add support for the UStealth format for Wii U.

For be clear, UStealth is a program on Windows and Wii homebrew. Usually, if the Wii U senses a NTFS or FAT32 partition it will ask if you want to format it at every boot. UStealth "hides" the drive from being detected so you don't get that nagging message. There are other uses for it too, but the point is that UStealth hides the hard drive from being seen. So multiple different apps add support for UStealth so that it can see a hard drive, even if it is hidden.
