### PR TITLE
Add lstat support

### DIFF
--- a/source/libfat.c
+++ b/source/libfat.c
@@ -67,6 +67,7 @@ static const devoptab_t dotab_fat = {
 	NULL,	// chmod_r
 	NULL,	// fchmod_r
 	_FAT_rmdir_r,
+	_FAT_stat_r, // This is lstat, but we don't support symlinks
 };
 
 bool fatMount (const char* name, const DISC_INTERFACE* interface, sec_t startSector, uint32_t cacheSize, uint32_t SectorsPerPage) {


### PR DESCRIPTION
The lstat() function is identical to stat(), except that it does not follow symbolic links. Since we don't support symbolic links in libfat, for us these functions are completely equivalent.