### PR TITLE
Modernize platform macro names

### DIFF
--- a/gba/Makefile
+++ b/gba/Makefile
@@ -33,7 +33,7 @@ CFLAGS	:=	-g -Wall -O2\
 		-ffast-math \
 		$(ARCH)
 
-CFLAGS	+=	$(INCLUDE) -DGBA
+CFLAGS	+=	$(INCLUDE) -D__GBA__
 CXXFLAGS	:=	$(CFLAGS)
 
 ASFLAGS	:=	-g $(ARCH)

--- a/include/fat.h
+++ b/include/fat.h
@@ -38,10 +38,10 @@ extern "C" {
 
 #include "libfatversion.h"
 
-// When compiling for NDS, make sure NDS is defined
-#ifndef NDS
- #if defined ARM9 || defined ARM7
-  #define NDS
+// When compiling for NDS, make sure __NDS__ is defined, as old Makefiles don't define it
+#if !defined __NDS__ && !defined __GBA__
+ #if defined NDS || defined ARM9 || defined ARM7
+  #define __NDS__
  #endif
 #endif
 
@@ -50,7 +50,7 @@ extern "C" {
 #if defined(__gamecube__) || defined (__wii__)
 #  include <ogc/disc_io.h>
 #else
-#  ifdef NDS
+#  ifdef __NDS__
 #    include <nds/disc_io.h>
 #  else
 #    include <disc_io.h>

--- a/nds/Makefile
+++ b/nds/Makefile
@@ -32,7 +32,7 @@ CFLAGS	:=	-g -Wall -O2 \
 		-ffast-math \
 		$(ARCH)
 
-CFLAGS	+=	$(INCLUDE) -DARM9 -DNDS
+CFLAGS	+=	$(INCLUDE) -DARM9 -D__NDS__
 CXXFLAGS	:=	$(CFLAGS)
 
 ASFLAGS	:=	-g $(ARCH)

--- a/source/common.h
+++ b/source/common.h
@@ -33,23 +33,16 @@
 #include <stddef.h>
 #include <stdint.h>
 
-// When compiling for NDS, make sure NDS is defined
-#ifndef NDS
- #if defined ARM9 || defined ARM7
-  #define NDS
- #endif
-#endif
-
 // Platform specific includes
 #if defined(__gamecube__) || defined (__wii__)
    #include <gctypes.h>
    #include <ogc/disc_io.h>
    #include <gccore.h>
-#elif defined(NDS)
+#elif defined(__NDS__)
    #include <nds/ndstypes.h>
    #include <nds/system.h>
    #include <nds/disc_io.h>
-#elif defined(GBA)
+#elif defined(__GBA__)
    #include <gba_types.h>
    #include <disc_io.h>
 #elif defined(GP2X)
@@ -68,11 +61,11 @@
    #define DEFAULT_SECTORS_PAGE 64
    #define USE_LWP_LOCK
    #define USE_RTC_TIME
-#elif defined (NDS)
+#elif defined (__NDS__)
    #define DEFAULT_CACHE_PAGES 16
    #define DEFAULT_SECTORS_PAGE 8
    #define USE_RTC_TIME
-#elif defined (GBA)
+#elif defined (__GBA__)
    #define DEFAULT_CACHE_PAGES 2
    #define DEFAULT_SECTORS_PAGE 8
    #define LIMIT_SECTORS 128

--- a/source/disc.c
+++ b/source/disc.c
@@ -91,7 +91,7 @@ const INTERFACE_ID _FAT_disc_interfaces[] = {
 };	
 
 /* ====================== NDS ====================== */
-#elif defined (NDS)
+#elif defined (__NDS__)
 #include <nds/system.h>
 #include <nds/memory.h>
 #include <nds/arm9/dldi.h>
@@ -103,7 +103,7 @@ const INTERFACE_ID _FAT_disc_interfaces[] = {
 };	
 
 /* ====================== GBA ====================== */
-#elif defined (GBA)
+#elif defined (__GBA__)
 #include <disc.h>
 
 const INTERFACE_ID _FAT_disc_interfaces[] = {


### PR DESCRIPTION
I removed the unnecessary macro logic from the internal header, but since lots of people are still using older Makefiles, and the *current* ones don't define these macros either (I'll take care of that shortly), the logic in the public header is still needed.